### PR TITLE
test(pdf): improve pdf rendering test

### DIFF
--- a/test/server-unit/pdf.spec.js
+++ b/test/server-unit/pdf.spec.js
@@ -28,6 +28,7 @@ const generatedFile = path.join(fixturesPath, '/pdf-sample.pdf');
 function PDFRenderUnitTest() {
   it('#wkhtmltopdf() creates correctly a PDF file from an HTML', async () => {
     const wk = await exec(`wkhtmltopdf ${htmlFile} ${generatedFile}`);
+    // this should be cleaned up.
   });
 
   it('#pdf.render() renders a valid PDF file', async () => {
@@ -49,8 +50,16 @@ function PDFRenderUnitTest() {
     expect(isBufferInstance(rendered)).to.equal(true);
     expect(isBufferInstance(cached)).to.equal(true);
 
-    expect(rendered).to.deep.equal(cached);
+    expect(sliceOutCreationDate(rendered)).to.deep.equal(sliceOutCreationDate(cached));
   });
+}
+
+function sliceOutCreationDate(buffer) {
+  const start = buffer.indexOf('CreationDate');
+  const end = buffer.indexOf(')', start) + 1;
+  const firstPart = buffer.slice(0, start);
+  const secondPart = buffer.slice(end);
+  return Buffer.concat([firstPart, secondPart]);
 }
 
 /**


### PR DESCRIPTION
This commit does the following things:
 1. Uses ms/fs to have promisified node FS methods.
 2. Mocks the `lib/html` renderer to return the same string it was
 inputted.
 3. Directly compares buffers instead of converting to strings.

The test doesn't pass, but it gets a large amount of the way!